### PR TITLE
Change `gridPoint` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The other props are passed to underlay svg polygon element.
 
 ### `gridPoint(type, size, gridX, gridY, oX=0, oY=0)`
 
-__return: `[x, y]`__
+__return: `{ center: [x, y], grid: [gridX, gridY], corners: [[cx0, cy0] ... [cx5, cy5]] }`__
 
 Helper function to calculate hexagon location in grid.
 
@@ -90,7 +90,7 @@ Helper function to calculate hexagon location in grid.
 
 ### `gridPoints(type, size, oX, oY, gridWidth, gridHeight)`
 
-__return: `[[x0, y0, gridX0, gridY0], [x1, y1 gridX1, gridY1] ...]`__
+__return: `[ { center: [x, y], grid: [gridX, gridY], corners: [[cx0, cy0] ... [cx5, cy5]] } ...]`__
 
 Helper function to bulk calculate hexagon location in grid.
 

--- a/dev/entry.jsx
+++ b/dev/entry.jsx
@@ -6,7 +6,7 @@ import { PointyToppedHex, FlatToppedHex, gridPoints } from '../src/index.jsx';
 const size = 30;
 
 const PTHComponent = () => {
-  const Hexes = gridPoints('pointy-topped', size, 100, 100, 10, 10).map(([x, y, gridX, gridY]) => {
+  const Hexes = gridPoints('pointy-topped', size, 100, 100, 10, 10).map(({ center: [x, y], grid: [gridX, gridY] }) => {
     return (
       <g key={`${x}-${y}`}>
         <PointyToppedHex
@@ -21,6 +21,7 @@ const PTHComponent = () => {
       </g>
     );
   });
+
   return (
     <div>
       <h2>PointyToppedHex</h2>
@@ -32,7 +33,7 @@ const PTHComponent = () => {
 };
 
 const FTHComponent = () => {
-  const Hexes = gridPoints('flat-topped', size, 100, 100, 10, 10).map(([x, y, gridX, gridY]) => {
+  const Hexes = gridPoints('flat-topped', size, 100, 100, 10, 10).map(({ center: [x, y], grid: [gridX, gridY] }) => {
     return (
       <g key={`${x}-${y}`}>
         <FlatToppedHex
@@ -46,6 +47,7 @@ const FTHComponent = () => {
       </g>
     );
   });
+
   return (
     <div>
       <h2>FlatToppedHex</h2>

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,14 +33,30 @@ export const gridPoint = (type, size, gridX, gridY, relativeX = 0, relativeY = 0
     const diffXFromY = gridY * width / 2;
     const gridPointX = gridX * width + diffXFromY;
     const gridPointY = gridY * height * 0.75;
-    return [gridPointX + relativeX, gridPointY + relativeY];
+
+    const x = gridPointX + relativeX;
+    const y = gridPointY + relativeY;
+
+    return {
+      center: [x, y],
+      corners: hexCorners(type, x, y, size),
+      grid: [gridX, gridY],
+    };
   } else if (type === FLAT) {
     const width = size * 2;
     const height = size * SQRT3;
     const diffXFromY = gridY * width * 0.75;
     const gridPointX = gridX * width * 1.5 + diffXFromY;
     const gridPointY = gridY * height / 2;
-    return [gridPointX + relativeX, gridPointY + relativeY];
+
+    const x = gridPointX + relativeX;
+    const y = gridPointY + relativeY;
+
+    return {
+      center: [x, y],
+      corners: hexCorners(type, x, y, size),
+      grid: [gridX, gridY],
+    };
   } else {
     throw new Error(`grid type was either ${POINTY} or ${FLAT}`);
   }
@@ -49,4 +65,4 @@ export const gridPoint = (type, size, gridX, gridY, relativeX = 0, relativeY = 0
 
 export const gridPoints = (type, size, baseX, baseY, gridWidth, gridHeight) =>
   product(gridHeight, gridWidth).map(([gridY, gridX]) =>
-    gridPoint(type, size, gridX, gridY, baseX, baseY).concat([gridX, gridY]));
+    gridPoint(type, size, gridX, gridY, baseX, baseY));

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,7 @@ export const hexCorners = (type, x, y, size) => {
   });
 };
 
-export const gridPoint = (type, size, gridX, gridY, relativeX = 0, relativeY = 0) => {
+export const gridPoint = (type, size, gridX, gridY, oX = 0, oY = 0) => {
   /* eslint-disable no-else-return */
   /* reason: it seems buggy */
   if (type === POINTY) {
@@ -34,8 +34,8 @@ export const gridPoint = (type, size, gridX, gridY, relativeX = 0, relativeY = 0
     const gridPointX = gridX * width + diffXFromY;
     const gridPointY = gridY * height * 0.75;
 
-    const x = gridPointX + relativeX;
-    const y = gridPointY + relativeY;
+    const x = gridPointX + oX;
+    const y = gridPointY + oY;
 
     return {
       center: [x, y],
@@ -49,8 +49,8 @@ export const gridPoint = (type, size, gridX, gridY, relativeX = 0, relativeY = 0
     const gridPointX = gridX * width * 1.5 + diffXFromY;
     const gridPointY = gridY * height / 2;
 
-    const x = gridPointX + relativeX;
-    const y = gridPointY + relativeY;
+    const x = gridPointX + oX;
+    const y = gridPointY + oY;
 
     return {
       center: [x, y],
@@ -63,6 +63,6 @@ export const gridPoint = (type, size, gridX, gridY, relativeX = 0, relativeY = 0
   /* eslint-enable no-else-return */
 };
 
-export const gridPoints = (type, size, baseX, baseY, gridWidth, gridHeight) =>
+export const gridPoints = (type, size, oX, oY, gridWidth, gridHeight) =>
   product(gridHeight, gridWidth).map(([gridY, gridX]) =>
-    gridPoint(type, size, gridX, gridY, baseX, baseY));
+    gridPoint(type, size, gridX, gridY, oX, oY));

--- a/test/utils.js
+++ b/test/utils.js
@@ -33,23 +33,219 @@ describe('hexCorners', () => {
 
 describe('gridPoint', () => {
   it('should return center point of pointy-topped hexagonal grid system', () => {
-    assert.deepEqual(gridPoint('pointy-topped', 100, 0, 0), [0, 0]);
-    assert.deepEqual(gridPoint('pointy-topped', 10, 0, 0), [0, 0]);
-    assert.deepEqual(gridPoint('pointy-topped', 1, 0, 0), [0, 0]);
-    assert.deepEqual(gridPoint('pointy-topped', 0, 0, 0), [0, 0]);
-    assert.deepEqual(gridPoint('pointy-topped', 100, 10, 10), [2598.0762113533156, 1500]);
-    assert.deepEqual(gridPoint('pointy-topped', 10, 10, 10), [259.80762113533156, 150]);
-    assert.deepEqual(gridPoint('pointy-topped', 1, 10, 10), [25.980762113533156, 15]);
+    assert.deepEqual(
+      gridPoint('pointy-topped', 100, 0, 0),
+      {
+        center: [0, 0],
+        grid: [0, 0],
+        corners: [
+          [86.60254037844388, 49.99999999999999],
+          [6.123233995736766e-15, 100],
+          [-86.60254037844388, 49.99999999999999],
+          [-86.60254037844386, -50.000000000000014],
+          [-1.8369701987210297e-14, -100],
+          [86.60254037844383, -50.00000000000004],
+        ],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('pointy-topped', 10, 0, 0),
+      {
+        center: [0, 0],
+        grid: [0, 0],
+        corners: [
+          [8.660254037844387, 4.999999999999999],
+          [6.123233995736766e-16, 10],
+          [-8.660254037844387, 4.999999999999999],
+          [-8.660254037844386, -5.000000000000001],
+          [-1.8369701987210296e-15, -10],
+          [8.660254037844384, -5.000000000000004],
+        ],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('pointy-topped', 1, 0, 0),
+      {
+        center: [0, 0],
+        grid: [0, 0],
+        corners: [
+          [0.8660254037844387, 0.49999999999999994],
+          [6.123233995736766e-17, 1],
+          [-0.8660254037844387, 0.49999999999999994],
+          [-0.8660254037844386, -0.5000000000000001],
+          [-1.8369701987210297e-16, -1],
+          [0.8660254037844384, -0.5000000000000004],
+        ],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('pointy-topped', 0, 0, 0),
+      {
+        center: [0, 0],
+        grid: [0, 0],
+        corners: [
+          [0, 0],
+          [0, 0],
+          [0, 0],
+          [0, 0],
+          [0, 0],
+          [0, 0],
+        ],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('pointy-topped', 100, 10, 10),
+      {
+        center: [2598.0762113533156, 1500],
+        grid: [10, 10],
+        corners: [
+          [2684.6787517317593, 1550],
+          [2598.0762113533156, 1600],
+          [2511.4736709748718, 1550],
+          [2511.4736709748718, 1450],
+          [2598.0762113533156, 1400],
+          [2684.6787517317593, 1450],
+        ],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('pointy-topped', 10, 10, 10),
+      {
+        center: [259.80762113533156, 150],
+        grid: [10, 10],
+        corners: [
+          [268.4678751731759, 155],
+          [259.80762113533154, 160],
+          [251.14736709748715, 155],
+          [251.14736709748715, 145],
+          [259.80762113533154, 140],
+          [268.4678751731759, 145],
+        ],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('pointy-topped', 1, 10, 10),
+      {
+        center: [25.980762113533156, 15],
+        grid: [10, 10],
+        corners: [
+          [26.846787517317594, 15.5],
+          [25.980762113533157, 16],
+          [25.11473670974872, 15.5],
+          [25.11473670974872, 14.5],
+          [25.980762113533157, 14],
+          [26.846787517317594, 14.5],
+        ],
+      }
+    );
   });
 
   it('should return center point of flat-topped hexagonal grid system', () => {
-    assert.deepEqual(gridPoint('flat-topped', 100, 0, 0), [0, 0]);
-    assert.deepEqual(gridPoint('flat-topped', 10, 0, 0), [0, 0]);
-    assert.deepEqual(gridPoint('flat-topped', 1, 0, 0), [0, 0]);
-    assert.deepEqual(gridPoint('flat-topped', 0, 0, 0), [0, 0]);
-    assert.deepEqual(gridPoint('flat-topped', 100, 10, 10), [4500, 866.0254037844386]);
-    assert.deepEqual(gridPoint('flat-topped', 10, 10, 10), [450, 86.60254037844385]);
-    assert.deepEqual(gridPoint('flat-topped', 1, 10, 10), [45, 8.660254037844386]);
+    assert.deepEqual(
+      gridPoint('flat-topped', 100, 0, 0),
+      {
+        center: [0, 0],
+        corners: [
+          [100, 0],
+          [50.000000000000014, 86.60254037844386],
+          [-49.99999999999998, 86.60254037844388],
+          [-100, 1.2246467991473532e-14],
+          [-50.00000000000004, -86.60254037844383],
+          [50.000000000000014, -86.60254037844386],
+        ],
+        grid: [0, 0],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('flat-topped', 10, 0, 0),
+      {
+        center: [0, 0],
+        corners: [
+          [10, 0],
+          [5.000000000000001, 8.660254037844386],
+          [-4.999999999999998, 8.660254037844387],
+          [-10, 1.2246467991473533e-15],
+          [-5.000000000000004, -8.660254037844384],
+          [5.000000000000001, -8.660254037844386],
+        ],
+        grid: [0, 0],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('flat-topped', 1, 0, 0),
+      {
+        center: [0, 0],
+        corners: [
+          [1, 0],
+          [0.5000000000000001, 0.8660254037844386],
+          [-0.4999999999999998, 0.8660254037844387],
+          [-1, 1.2246467991473532e-16],
+          [-0.5000000000000004, -0.8660254037844384],
+          [0.5000000000000001, -0.8660254037844386],
+        ],
+        grid: [0, 0],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('flat-topped', 0, 0, 0),
+      {
+        center: [0, 0],
+        corners: [
+          [0, 0],
+          [0, 0],
+          [0, 0],
+          [0, 0],
+          [0, 0],
+          [0, 0],
+        ],
+        grid: [0, 0],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('flat-topped', 100, 10, 10),
+      {
+        center: [4500, 866.0254037844386],
+        corners: [
+          [4600, 866.0254037844386],
+          [4550, 952.6279441628825],
+          [4450, 952.6279441628825],
+          [4400, 866.0254037844386],
+          [4450, 779.4228634059948],
+          [4550, 779.4228634059947],
+        ],
+        grid: [10, 10],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('flat-topped', 10, 10, 10),
+      {
+        center: [450, 86.60254037844385],
+        corners: [
+          [460, 86.60254037844385],
+          [455, 95.26279441628823],
+          [445, 95.26279441628823],
+          [440, 86.60254037844385],
+          [445, 77.94228634059947],
+          [455, 77.94228634059947],
+        ],
+        grid: [10, 10],
+      }
+    );
+    assert.deepEqual(
+      gridPoint('flat-topped', 1, 10, 10),
+      {
+        center: [45, 8.660254037844386],
+        corners: [
+          [46, 8.660254037844386],
+          [45.5, 9.526279441628825],
+          [44.5, 9.526279441628825],
+          [44, 8.660254037844386],
+          [44.5, 7.794228634059947],
+          [45.5, 7.794228634059947],
+        ],
+        grid: [10, 10],
+      }
+    );
   });
 });
 
@@ -57,15 +253,15 @@ describe('gridPoints', () => {
   it('should return sequential gridPoints (pointy-topped)', () => {
     const result = gridPoints('pointy-topped', 30, 13, 48, 3, 3);
     const expected = [
-      gridPoint('pointy-topped', 30, 0, 0, 13, 48).concat([0, 0]),
-      gridPoint('pointy-topped', 30, 1, 0, 13, 48).concat([1, 0]),
-      gridPoint('pointy-topped', 30, 2, 0, 13, 48).concat([2, 0]),
-      gridPoint('pointy-topped', 30, 0, 1, 13, 48).concat([0, 1]),
-      gridPoint('pointy-topped', 30, 1, 1, 13, 48).concat([1, 1]),
-      gridPoint('pointy-topped', 30, 2, 1, 13, 48).concat([2, 1]),
-      gridPoint('pointy-topped', 30, 0, 2, 13, 48).concat([0, 2]),
-      gridPoint('pointy-topped', 30, 1, 2, 13, 48).concat([1, 2]),
-      gridPoint('pointy-topped', 30, 2, 2, 13, 48).concat([2, 2]),
+      gridPoint('pointy-topped', 30, 0, 0, 13, 48),
+      gridPoint('pointy-topped', 30, 1, 0, 13, 48),
+      gridPoint('pointy-topped', 30, 2, 0, 13, 48),
+      gridPoint('pointy-topped', 30, 0, 1, 13, 48),
+      gridPoint('pointy-topped', 30, 1, 1, 13, 48),
+      gridPoint('pointy-topped', 30, 2, 1, 13, 48),
+      gridPoint('pointy-topped', 30, 0, 2, 13, 48),
+      gridPoint('pointy-topped', 30, 1, 2, 13, 48),
+      gridPoint('pointy-topped', 30, 2, 2, 13, 48),
     ];
     assert.deepEqual(result, expected);
   });
@@ -73,15 +269,15 @@ describe('gridPoints', () => {
   it('should return sequential gridPoints (flat-topped)', () => {
     const result = gridPoints('flat-topped', 30, 13, 48, 3, 3);
     const expected = [
-      gridPoint('flat-topped', 30, 0, 0, 13, 48).concat([0, 0]),
-      gridPoint('flat-topped', 30, 1, 0, 13, 48).concat([1, 0]),
-      gridPoint('flat-topped', 30, 2, 0, 13, 48).concat([2, 0]),
-      gridPoint('flat-topped', 30, 0, 1, 13, 48).concat([0, 1]),
-      gridPoint('flat-topped', 30, 1, 1, 13, 48).concat([1, 1]),
-      gridPoint('flat-topped', 30, 2, 1, 13, 48).concat([2, 1]),
-      gridPoint('flat-topped', 30, 0, 2, 13, 48).concat([0, 2]),
-      gridPoint('flat-topped', 30, 1, 2, 13, 48).concat([1, 2]),
-      gridPoint('flat-topped', 30, 2, 2, 13, 48).concat([2, 2]),
+      gridPoint('flat-topped', 30, 0, 0, 13, 48),
+      gridPoint('flat-topped', 30, 1, 0, 13, 48),
+      gridPoint('flat-topped', 30, 2, 0, 13, 48),
+      gridPoint('flat-topped', 30, 0, 1, 13, 48),
+      gridPoint('flat-topped', 30, 1, 1, 13, 48),
+      gridPoint('flat-topped', 30, 2, 1, 13, 48),
+      gridPoint('flat-topped', 30, 0, 2, 13, 48),
+      gridPoint('flat-topped', 30, 1, 2, 13, 48),
+      gridPoint('flat-topped', 30, 2, 2, 13, 48),
     ];
     assert.deepEqual(result, expected);
   });

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -38,20 +38,6 @@ const config = {
     Buffer: false,
   },
   devTool: 'inline-source-map',
-  externals: {
-    react: {
-      root: 'React',
-      commonjs2: 'react',
-      commonjs: 'react',
-      amd: 'react',
-    },
-    'react-dom': {
-      root: 'ReactDOM',
-      commonjs2: 'react-dom',
-      commonjs: 'react-dom',
-      amd: 'react-dom',
-    },
-  },
   devServer: {
     contentBase: 'lib',
     port: 9000,


### PR DESCRIPTION
Now, gridPoint returns 

+ [x, y] coordinates of hex center
+ [gridX, gridY] coordinates in hexagonal grids
+ [[cx0, cy0] ... [cx5, cy5]] coordinates of hex corners