### PR TITLE
React.PropTypes is depreciated

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "jsdom-global": "2.1.1",
     "mocha": "3.2.0",
     "npm-run-all": "3.1.2",
+    "prop-types" : "15.6.0",
     "react": "15.4.1",
     "react-addons-test-utils": "15.4.1",
     "react-dom": "15.4.1",

--- a/src/Hex.js
+++ b/src/Hex.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import { corners } from './utils';
 

--- a/src/Hex.js
+++ b/src/Hex.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import { corners } from './utils';
 
 const Hex = (props) => {


### PR DESCRIPTION
This will keep react-hex running after the next update to react (and silence the warning message in the console)

As per: https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes

